### PR TITLE
Switch jquery.cookie to mediawiki.cookie

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -5,7 +5,7 @@
 		"[http://www.organicdesign.co.nz/aran Aran Dunkley]",
 		"[http://absorto.dev Igor Absorto]"
 	],
-	"url": "http://www.mediawiki.org/wiki/Extension:TreeAndMenu",
+	"url": "https://www.mediawiki.org/wiki/Extension:TreeAndMenu",
 	"descriptionmsg": "treeandmenu-desc",
 	"license-name": "[https://www.gnu.org/licenses/gpl-2.0.html GNU General Public Licence 2.0] or later",
 	"type": "parserhook",
@@ -25,9 +25,7 @@
 		"TreeAndMenu": ["i18n"]
 	},
 	"Hooks": {
-		"SkinBuildSidebar": [
-			"TreeAndMenu::onSkinBuildSidebar"
-		]
+		"SkinBuildSidebar": "TreeAndMenu::onSkinBuildSidebar"
 	},
 	"ResourceModules": {
 		"ext.treeandmenu": {
@@ -41,7 +39,7 @@
 			],
 			"dependencies": [
 				"jquery.ui",
-				"jquery.cookie",
+				"mediawiki.cookie",
 				"jquery.client"
 			],
 			"targets": [
@@ -54,5 +52,5 @@
 		"localBasePath": "",
 		"remoteExtPath": "TreeAndMenu"
 	},
-	"manifest_version": 1
+	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -11,9 +11,21 @@
 	"type": "parserhook",
 	"callback": "TreeAndMenu::onRegistration",
 	"config": {
-		"TreeAndMenuPersistIfId": false,           "@": "Makes trees with id attributes have persistent state",
-		"TreeAndMenuSidebarMenuPage": false,           "@": "Specify menu page to be used as a sidebar menu",
-		"TreeAndMenuSidebarMenuHeading": false,           "@": "Specify the heading line for sidebar menu"
+		"TreeAndMenuPersistIfId": {
+			"description": "Makes trees with id attributes have persistent state",
+			"public": true,
+			"value": false
+		},
+		"TreeAndMenuSidebarMenuPage": {
+			"description": "Specify menu page to be used as a sidebar menu",
+			"public": true,
+			"value": false
+		},
+		"TreeAndMenuSidebarMenuHeading": {
+			"description": "Specify the heading line for sidebar menu",
+			"public": true,
+			"value": false
+		}
 	},
 	"AutoloadClasses": {
 		"TreeAndMenu": "TreeAndMenu_body.php"


### PR DESCRIPTION
Module was removed in https://github.com/wikimedia/mediawiki/commit/7c605f24285ddcddb3bb9b1ddac5c70cba7b5216

Also switch to manifest version 2.