### PR TITLE
Update Sidebar hooks to work with MW 1.39+

### DIFF
--- a/TreeAndMenu_body.php
+++ b/TreeAndMenu_body.php
@@ -167,10 +167,23 @@ class TreeAndMenu {
 			$title = Title::newFromText( $wgTreeAndMenuSidebarMenuPage );
 			if ( $title && $title->exists() && !$skin->getOutput()->getTitle()->equals( $title ) ) {
 				$html = self::getTreeHtmlFromPage( $title, $skin->getOutput() );
-				$bar[ $wgTreeAndMenuSidebarMenuHeading ? $wgTreeAndMenuSidebarMenuHeading : 'Outline' ] = $html;
+				// Create empty heading for SkinAfterPortlet to attach content to
+				$bar[ $wgTreeAndMenuSidebarMenuHeading ? $wgTreeAndMenuSidebarMenuHeading : 'Outline' ] = [];
 			}
 		}
 		return true;
+	}
+
+	public static function onSkinAfterPortlet( Skin $skin, string $portletName, string &$html ) {
+		global $wgTreeAndMenuSidebarMenuPage, $wgTreeAndMenuSidebarMenuHeading;
+		$headingName = $wgTreeAndMenuSidebarMenuHeading ? $wgTreeAndMenuSidebarMenuHeading : 'Outline';
+
+		if ( $wgTreeAndMenuSidebarMenuPage && $portletName === $headingName ) {
+			$title = Title::newFromText( $wgTreeAndMenuSidebarMenuPage );
+			if ( $title && $title->exists() && !$skin->getOutput()->getTitle()->equals( $title ) ) {
+				$html .= self::getTreeHtmlFromPage( $title, $skin->getOutput() );
+			}
+		}
 	}
 
 	/**

--- a/extension.json
+++ b/extension.json
@@ -40,7 +40,11 @@
 		"TreeAndMenu": ["i18n"]
 	},
 	"Hooks": {
-		"SkinBuildSidebar": "TreeAndMenu::onSkinBuildSidebar"
+		"SkinBuildSidebar": "TreeAndMenu::onSkinBuildSidebar",
+		"SkinAfterPortlet": "TreeAndMenu::onSkinAfterPortlet"
+	},
+	"requires": {
+		"MediaWiki": ">= 1.35.0"
 	},
 	"ResourceModules": {
 		"ext.treeandmenu": {

--- a/extension.json
+++ b/extension.json
@@ -43,9 +43,6 @@
 		"SkinBuildSidebar": "TreeAndMenu::onSkinBuildSidebar",
 		"SkinAfterPortlet": "TreeAndMenu::onSkinAfterPortlet"
 	},
-	"requires": {
-		"MediaWiki": ">= 1.35.0"
-	},
 	"ResourceModules": {
 		"ext.treeandmenu": {
 			"styles": ["fancytree/fancytree.css", "suckerfish/suckerfish.css"],


### PR DESCRIPTION
The SkinBuildSidebar no longer accepts raw HTML, and will fail if it's not passed an array.  There's a different hook added in 1.35, SkinAfterPortlet, which places HTML content after a portlet. But we still need the first hook to create a portlet, if it's given.

Currently what will happen if you use an existing portlet name is that Mediawiki will just overwrite the empty array, which means you can also append to an existing portlet.

I'm sure it won't surprise you to hear that I've been working on upgrading SEBoK, since this is an undocumented interface.