### PR TITLE
Fix compatibility issues and raise requirement to 1.43

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -8,6 +8,9 @@
 	"url": "https://www.mediawiki.org/wiki/Extension:TreeAndMenu",
 	"descriptionmsg": "treeandmenu-desc",
 	"license-name": "[https://www.gnu.org/licenses/gpl-2.0.html GNU General Public Licence 2.0] or later",
+	"requires": {
+		"MediaWiki": ">= 1.43"
+	},
 	"type": "parserhook",
 	"callback": "TreeAndMenu::onRegistration",
 	"config": {


### PR DESCRIPTION
* Use namespaced Title (required for 1.44+ compatibility)
* Use ParserOutput::runOutputPipeline instead of ::getText (removed in 1.45)
* Use WikiPageFactory::newFromID instead of WikiPage:newFromID (removed in 1.41)
* Set MW requirement to 1.43 (1.39 will be EOL at the end of the month; 1.40-1.42 have already been EOL for a while)